### PR TITLE
fix: bad color number

### DIFF
--- a/lua/lsp-inlayhints/config.lua
+++ b/lua/lsp-inlayhints/config.lua
@@ -1,12 +1,12 @@
 local function setInlayHintHL()
   local hl = vim.api.nvim_get_hl_by_name("Comment", true)
-  local foreground = string.format("#%x", hl["foreground"] or 0)
+  local foreground = string.format("#%06x", hl["foreground"] or 0)
   if #foreground < 3 then
     foreground = ""
   end
 
   hl = vim.api.nvim_get_hl_by_name("CursorLine", true)
-  local background = string.format("#%x", hl["background"] or 0)
+  local background = string.format("#%06x", hl["background"] or 0)
   if #foreground < 3 then
     background = ""
   end


### PR DESCRIPTION
Steps to reproduce:

Without this change `#073642` -> translates into :
```
local has_hl, _ = pcall(vim.api.nvim_get_hl_by_name, "Comment")
print(has_hl)
hl = vim.api.nvim_get_hl_by_name("CursorLine", true)
local background = string.format("#%x", hl["background"] or 0)
print(background)
```

```
false
#73642
```


With this change:

```
local has_hl, _ = pcall(vim.api.nvim_get_hl_by_name, "Comment")
print(has_hl)
hl = vim.api.nvim_get_hl_by_name("CursorLine", true)
local background = string.format("#%06x", hl["background"] or 0)
print(background)
```

It works: 
```
false
#073642
```