### PR TITLE
adjust arguments order to match conventions

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ You can lazy load it on `module` or `LspAttach` event if you're calling it
 ### on_attach
 
 ```lua
-require("lsp-inlayhints").on_attach(bufnr, client)
+require("lsp-inlayhints").on_attach(client, bufnr)
 ```
 
 ### LspAttach
@@ -31,7 +31,7 @@ vim.api.nvim_create_autocmd("LspAttach", {
 
     local bufnr = args.buf
     local client = vim.lsp.get_client_by_id(args.data.client_id)
-    require("lsp-inlayhints").on_attach(bufnr, client)
+    require("lsp-inlayhints").on_attach(client, bufnr)
   end,
 })
 ```

--- a/lua/lsp-inlayhints/core.lua
+++ b/lua/lsp-inlayhints/core.lua
@@ -43,7 +43,7 @@ end
 ---@param bufnr number
 ---@param client table A |vim.lsp.client| object
 ---@param force boolean Whether to call the server regardless of capability
-function M.on_attach(bufnr, client, force)
+function M.on_attach(client, bufnr, force)
   if not client then
     vim.notify_once("[LSP Inlayhints] Tried to attach to a nil client.", vim.log.levels.ERROR)
     return

--- a/lua/lsp-inlayhints/core.lua
+++ b/lua/lsp-inlayhints/core.lua
@@ -19,15 +19,6 @@ vim.lsp.handlers["workspace/inlayHint/refresh"] = function(_, _, ctx)
 end
 
 local function set_store(client, bufnr)
-  -- TODO Remove
-   if type(bufnr) == "table" and type(client) == "number" then
-     vim.notify_once(
-       "[LSP Inlayhints] on_attach should be called with (client, bufnr)",
-       vim.log.levels.WARN
-     )
-
-     client, bufnr = bufnr, client
-   end
   if not store.b[bufnr].attached then
     vim.api.nvim_buf_attach(bufnr, false, {
       on_detach = function()

--- a/lua/lsp-inlayhints/core.lua
+++ b/lua/lsp-inlayhints/core.lua
@@ -18,7 +18,16 @@ vim.lsp.handlers["workspace/inlayHint/refresh"] = function(_, _, ctx)
   return vim.NIL
 end
 
-local function set_store(bufnr, client)
+local function set_store(client, bufnr)
+  -- TODO Remove
+   if type(bufnr) == "table" and type(client) == "number" then
+     vim.notify_once(
+       "[LSP Inlayhints] on_attach should be called with (client, bufnr)",
+       vim.log.levels.WARN
+     )
+
+     client, bufnr = bufnr, client
+   end
   if not store.b[bufnr].attached then
     vim.api.nvim_buf_attach(bufnr, false, {
       on_detach = function()
@@ -44,6 +53,15 @@ end
 ---@param client table A |vim.lsp.client| object
 ---@param force boolean Whether to call the server regardless of capability
 function M.on_attach(client, bufnr, force)
+  -- TODO Remove
+   if type(bufnr) == "table" and type(client) == "number" then
+     vim.notify_once(
+       "[LSP Inlayhints] on_attach should be called with (client, bufnr)",
+       vim.log.levels.WARN
+     )
+
+     client, bufnr = bufnr, client
+   end
   if not client then
     vim.notify_once("[LSP Inlayhints] Tried to attach to a nil client.", vim.log.levels.ERROR)
     return
@@ -65,7 +83,7 @@ function M.on_attach(client, bufnr, force)
     vim.notify_once("[LSP Inlayhints] attached to " .. client.name, vim.log.levels.TRACE)
   end
 
-  set_store(bufnr, client)
+  set_store(client, bufnr)
   M.setup_autocmd(bufnr)
 end
 


### PR DESCRIPTION
Hey! I had some weird errors, and after some debugging i noticed that you actually declared your `on_attach` func with `(bufnr, client)` args, wherefore in lsp docs its `on_attach(client, bufnr)`:

```
{on_attach}          Callback (client, bufnr) invoked when client
                              attaches to a buffer.
```

you can check it yourself `:h lsp`