### PR TITLE
feat: add `enabled_at_startup` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ local default_config = {
     -- highlight group
     highlight = "LspInlayHint",
   },
+  enabled_at_startup = true,
   debug_mode = false,
 }
 ```

--- a/lua/lsp-inlayhints/config.lua
+++ b/lua/lsp-inlayhints/config.lua
@@ -50,6 +50,7 @@ local default_config = {
     -- highlight group
     highlight = "LspInlayHint",
   },
+  enabled_at_startup = true,
   debug_mode = false,
 }
 

--- a/lua/lsp-inlayhints/core.lua
+++ b/lua/lsp-inlayhints/core.lua
@@ -6,7 +6,7 @@ local store = require("lsp-inlayhints.store")._store
 
 local AUGROUP = "_InlayHints"
 local ns = vim.api.nvim_create_namespace "textDocument/inlayHints"
-local enabled = true
+local enabled
 
 -- TODO Set client capability
 vim.lsp.handlers["workspace/inlayHint/refresh"] = function(_, _, ctx)
@@ -60,6 +60,8 @@ function M.on_attach(bufnr, client, force)
   then
     return
   end
+
+  enabled = config.options.enabled_at_startup
 
   if config.options.debug_mode then
     vim.notify_once("[LSP Inlayhints] attached to " .. client.name, vim.log.levels.TRACE)


### PR DESCRIPTION
### What

- Add a new option named `enabled_at_startup` in order to make us able to control whether inlay hints will be shown at startup by default or not.

### Why

- I'd like to show inlay hints only when I explicitly want to check them.