### PR TITLE
Fix instructions for using old tsserver version

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ require("rust-tools").setup({
 ### Typescript
 
 `tsserver` is spec compliant from [v1.1.0](https://github.com/typescript-language-server/typescript-language-server/releases/tag/v1.1.0) onwards. If you're using an older version, add
-`require("lsp-inlayhints").adapter.set_old_tsserver()`.
+`require("lsp-inlayhints.adapter").set_old_tsserver()`.
 
 See [typescript-language-server#workspacedidchangeconfiguration](https://github.com/typescript-language-server/typescript-language-server#workspacedidchangeconfiguration).
 


### PR DESCRIPTION
Currently, `README.md` suggests running
```lua
require("lsp-inlayhints").adapter.set_old_tsserver()
```
when using a version of `tsserver` older than 1.1.0. However, this fails with `attempt to index field 'adapter' (a nil value)` because `adapter` is not set on `M` in `init.lua`. The correct usage is to require the module directly:
```lua
require("lsp-inlayhints.adapter").set_old_tsserver()
```