### PR TITLE
fix: #43 #42 extmark error

### DIFF
--- a/lua/lsp-inlayhints/handler_helper.lua
+++ b/lua/lsp-inlayhints/handler_helper.lua
@@ -126,7 +126,7 @@ local render_hints = function(bufnr, parsed, namespace, range)
     if virt_text ~= "" then
       vim.api.nvim_buf_set_extmark(bufnr, namespace, line, 0, {
         virt_text = {
-          opts.max_len_align and { padding, "NONE" },
+          { padding, "NONE" },
           { virt_text, opts.highlight },
         },
         hl_mode = "combine",


### PR DESCRIPTION
```
virt_text : virtual text to link to this mark. A list of
                 [text, highlight] tuples, each representing a text chunk
                 with specified highlight. `highlight` element can either
                 be a single highlight group, or an array of multiple
                 highlight groups that will be stacked (highest priority
                 last). A highlight group can be supplied either as a
                 string or as an integer, the latter which can be obtained
                 using |nvim_get_hl_id_by_name()|.
```

Issue #42 #43

Simply display padding since it will be an empty string if `max_len_align` equals false.

Works fine with `max_len_align` equals false.
<img width="645" alt="image" src="https://user-images.githubusercontent.com/16725418/233802170-06af731a-9578-4da4-a84a-8b253f711e5f.png">
