### PR TITLE
feat!(position): optimize max_len align & add fixed_col align

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,22 +64,26 @@ local default_config = {
       remove_colon_start = false,
       remove_colon_end = true,
     },
+    -- type and other hints
     type_hints = {
-      -- type and other hints
       show = true,
       prefix = "",
       separator = ", ",
       remove_colon_start = false,
       remove_colon_end = false,
     },
+    position = {
+      -- where to show the hints. values can be:
+      --   nil: show hints after the end of the line
+      --   "max_len": show hints after the longest line in the file
+      --   "fixed_col": show hints after a fixed column, specified in padding
+      align = nil,
+      -- extra padding on the left if align is not nil
+      padding = 1,
+    },
     only_current_line = false,
-    -- separator between types and parameter hints. Note that type hints are
-    -- shown before parameter
+    -- separator between types and parameter hints. Note that type hints are shown before parameter
     labels_separator = "  ",
-    -- whether to align to the length of the longest line in the file
-    max_len_align = false,
-    -- padding from the left if max_len_align is true
-    max_len_align_padding = 1,
     -- highlight group
     highlight = "LspInlayHint",
     -- virt_text priority

--- a/lua/lsp-inlayhints/config.lua
+++ b/lua/lsp-inlayhints/config.lua
@@ -40,13 +40,18 @@ local default_config = {
       remove_colon_start = false,
       remove_colon_end = false,
     },
+    position = {
+      -- where to show the hints. values can be:
+      --   nil: show hints after the end of the line
+      --   "max_len": show hints after the longest line in the file
+      --   "fixed_col": show hints after a fixed column, specified in padding
+      align = nil,
+      -- extra padding on the left if align is not nil
+      padding = 1,
+    },
     only_current_line = false,
     -- separator between types and parameter hints. Note that type hints are shown before parameter
     labels_separator = "  ",
-    -- whether to align to the length of the longest line in the file
-    max_len_align = false,
-    -- padding from the left if max_len_align is true
-    max_len_align_padding = 1,
     -- highlight group
     highlight = "LspInlayHint",
     -- virt_text priority

--- a/lua/lsp-inlayhints/handler_helper.lua
+++ b/lua/lsp-inlayhints/handler_helper.lua
@@ -87,9 +87,11 @@ local function get_max_len(bufnr, parsed_data)
 end
 
 local render_hints = function(bufnr, parsed, namespace, range)
-  local max_len
-  if opts.max_len_align then
-    max_len = get_max_len(bufnr, parsed)
+  local virt_text_win_col = 0
+  if opts.position.align == "max_len" then
+    virt_text_win_col = opts.position.padding + get_max_len(bufnr, parsed)
+  elseif opts.position.align == "fixed_col" then
+    virt_text_win_col = opts.position.padding
   end
 
   if opts.only_current_line then
@@ -115,20 +117,12 @@ local render_hints = function(bufnr, parsed, namespace, range)
       virt_text = param_vt
     end
 
-    local padding = ""
-    if opts.max_len_align then
-      padding = string.rep(
-        " ",
-        max_len - current_line(bufnr, line):len() + opts.max_len_align_padding
-      )
-    end
-
     if virt_text ~= "" then
       vim.api.nvim_buf_set_extmark(bufnr, namespace, line, 0, {
         virt_text = {
-          { padding, "NONE" },
           { virt_text, opts.highlight },
         },
+        virt_text_win_col = virt_text_win_col,
         hl_mode = "combine",
         priority = opts.priority,
       })


### PR DESCRIPTION
I've changed the max_len_align/padding to a new key `position` so that the user can choose one of 3 options instead of having 2 bools. It should also simplify adding more alignment modes in the future (such as "right" from rust-tools.nvim).
I've also changed the code to use the `virt_text_win_col`, so that we don't have to calculate the padding for each line.